### PR TITLE
Update the report route to do data mapping on the server rather than client-side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "body-parser": "latest",
         "elasticsearch": "^16.7.1",
         "express": "~4.16.1",
+        "lodash": "^4.17.20",
         "nodemon": "^2.0.5"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "body-parser": "latest",
     "elasticsearch": "^16.7.1",
     "express": "~4.16.1",
+    "lodash": "^4.17.20",
     "nodemon": "^2.0.5"
   },
   "main": "index.js",


### PR DESCRIPTION
Change from doing data mapping from ES format to be on the server-side rather than in the frontend, so that the response
is in the format expected by the chart and data table components. There is probably a better way way to do this from ES directly in the final api.